### PR TITLE
Use HTTPS for geocoding request

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,7 @@ def fetch_forecast_data(
 
     try:
         geo_res = requests.get(
-            "http://api.openweathermap.org/geo/1.0/direct",
+            "https://api.openweathermap.org/geo/1.0/direct",
             params={"q": city, "limit": 1, "appid": OPENWEATHER_API_KEY},
             timeout=10,
         )


### PR DESCRIPTION
## Summary
- Switch geocoding lookup to the HTTPS OpenWeather endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb307556008322a7b8d892021ea923